### PR TITLE
closes #3 and closes #4

### DIFF
--- a/samples/RFC4566.abnf
+++ b/samples/RFC4566.abnf
@@ -12,13 +12,44 @@ session-description = proto-version
                       attribute-fields
                       media-descriptions
 
-proto-version =       %x76 "=" 1*DIGIT CRLF
+proto-version =       %x76 "=" 1*DIGIT CRLF !!!
+  [_, _, v, _] = tokens
+  {:ok, Map.put(state, :version, v)}
+!!!
                       ;this memo describes version 0
 
 origin-field =        %x6f "=" username SP sess-id SP sess-version SP
-                      nettype SP addrtype SP unicast-address CRLF
+                      nettype SP addrtype SP unicast-address CRLF !!!
+  [
+    _,
+    _,
+    username,
+    _,
+    sess_id,
+    _,
+    sess_version,
+    _,
+    net_type,
+    _,
+    addr_type,
+    _,
+    unicast,
+    _
+  ] = tokens
+  {:ok, Map.put(state, :origin, %{
+    username: username,
+    session_id: sess_id,
+    session_version: sess_version,
+    net_type: net_type,
+    address_type: addr_type,
+    unicast_address: unicast
+  })}
+!!!
 
-session-name-field =  %x73 "=" text CRLF
+session-name-field =  %x73 "=" text CRLF  !!!
+  [_, _, s, _] = tokens
+  {:ok, Map.put(state, :session_name, s)}
+!!!
 
 information-field =   [%x69 "=" text CRLF]
 
@@ -29,7 +60,9 @@ email-fields =        *(%x65 "=" email-address CRLF)
 phone-fields =        *(%x70 "=" phone-number CRLF)
 
 connection-field =    [%x63 "=" nettype SP addrtype SP
-                      connection-address CRLF]
+                      connection-address CRLF] !!!
+{:ok, state}
+!!!
                       ;a connection field must be present
                       ;in every media description or at the
                       ;session-level

--- a/samples/RFC5322-no-obs.abnf
+++ b/samples/RFC5322-no-obs.abnf
@@ -40,19 +40,25 @@ unstructured    =   (*([FWS] VCHAR) *WSP)
 date-time       =   [ day-of-week "," ] date time [CFWS]
 day-of-week     =   ([FWS] day-name)
 day-name        =   "Mon" / "Tue" / "Wed" / "Thu" / "Fri" / "Sat" / "Sun"
-date            =   day month year
-day             =   ([FWS] 1*2DIGIT FWS) !!!
-  {:ok, Map.put(state, :day, day)}
+date            =   day month year !!!
+  [d, m, y] = tokens
+  state = Map.put(state, :day, d)
+  state = Map.put(state, :month, m)
+  {:ok, Map.put(state, :year, y)}
+!!!
+day             =   ([FWS] 1*2DIGIT FWS)  !!!
+  {:ok, state, to_char_list String.strip(to_string(day))}
 !!!
 month           =   "Jan" / "Feb" / "Mar" / "Apr" /
                     "May" / "Jun" / "Jul" / "Aug" /
-                    "Sep" / "Oct" / "Nov" / "Dec" !!!
-  {:ok, Map.put(state, :month, month)}
-!!!
+                    "Sep" / "Oct" / "Nov" / "Dec"
 year            =   (FWS 4*DIGIT FWS) !!!
-  {:ok, Map.put(state, :year, year)}
+  {:ok, state, to_char_list String.strip(to_string(year))}
 !!!
-time            =   time-of-day zone
+time            =   time-of-day zone !!!
+  [_, tz] = tokens
+  {:ok, Map.put(state, :tz, tz)}
+!!!
 time-of-day     =   hour ":" minute [ ":" second ]
 hour            =   2DIGIT !!!
   {:ok, Map.put(state, :hour, hour)}
@@ -64,7 +70,7 @@ second          =   2DIGIT !!!
   {:ok, Map.put(state, :second, second)}
 !!!
 zone            =   (FWS ( "+" / "-" ) 4DIGIT) !!!
-  {:ok, Map.put(state, :tz, zone)}
+  {:ok, state, to_char_list String.strip(to_string(zone))}
 !!!
 address         =   mailbox / group
 mailbox         =   name-addr / addr-spec


### PR DESCRIPTION
This adds the possibility of having the equivalents of YACC's $$ (#4) and $n (#3), for rule value and token values respectively. Also, the return value for a rule is now by default a list with all the tokens that matched for that rule, in order.

Rule result ($$) MUST be a char_list by now, more work is required in the interpreter.ex module to support returning any type of value. Rule results are assumed to be char list (they are flattened and concatenated and passed as tokens to other rules when recursively processing the grammar)
