### PR TITLE
Dialyzer and deprecation fixes

### DIFF
--- a/lib/ex_abnf.ex
+++ b/lib/ex_abnf.ex
@@ -28,7 +28,7 @@ defmodule ABNF do
   @spec load_file(String.t) :: Grammar.t | no_return
   def load_file(file) do
     data = File.read! file
-    load to_char_list(data)
+    load to_charlist(data)
   end
 
   @doc """

--- a/lib/ex_abnf/grammar.ex
+++ b/lib/ex_abnf/grammar.ex
@@ -19,7 +19,7 @@ defmodule ABNF.Grammar do
 
   alias ABNF.Core, as: Core
   alias ABNF.Util, as: Util
-  @type t :: Map
+  @type t :: map()
 
   # rulelist = 1*( rule / (*WSP c-nl) )
   # As described in the Errata #3076

--- a/lib/ex_abnf/grammar.ex
+++ b/lib/ex_abnf/grammar.ex
@@ -27,7 +27,7 @@ defmodule ABNF.Grammar do
   Builds a Grammar.t from the given input (an ABNF text grammar). You should
   never use this one directly but use the ones in the ABNF module instead.
   """
-  @spec rulelist(char_list) :: t
+  @spec rulelist(charlist) :: t
   def rulelist(input) do
     {module_code, rest} = case code input do
       nil -> {"", input}

--- a/lib/ex_abnf/grammar.ex
+++ b/lib/ex_abnf/grammar.ex
@@ -69,6 +69,8 @@ defmodule ABNF.Grammar do
               else
                 {_, f, c} = v[:code]
                 str = str <> "def #{f}(state, rule, string_values, values) do\r\n"
+                # silence warnings about unused variables
+                str = str <> "\t_ = {state, rule, string_values, values}\r\n"
                 str = str <> "\t#{c}\r\n"
                 str = str <> "end\r\n"
                 str

--- a/lib/ex_abnf/interpreter.ex
+++ b/lib/ex_abnf/interpreter.ex
@@ -27,7 +27,7 @@ defmodule ABNF.Interpreter do
   Parses the given input using the given grammar.
   """
   @spec apply(
-    Grammar.t, String.t, char_list, term
+    Grammar.t, String.t, charlist, term
   ) :: ABNF.CaptureResult.t | no_return
   def apply(grammar, rule_str, input, state \\ nil) do
     rule_str = Util.rulename rule_str

--- a/lib/ex_abnf/interpreter.ex
+++ b/lib/ex_abnf/interpreter.ex
@@ -28,7 +28,7 @@ defmodule ABNF.Interpreter do
   """
   @spec apply(
     Grammar.t, String.t, char_list, term
-  ) :: CaptureResult.t | no_return
+  ) :: ABNF.CaptureResult.t | no_return
   def apply(grammar, rule_str, input, state \\ nil) do
     rule_str = Util.rulename rule_str
     case parse_real grammar, %{element: :rulename, value: rule_str}, input, state do

--- a/lib/ex_abnf/util.ex
+++ b/lib/ex_abnf/util.ex
@@ -21,7 +21,7 @@ defmodule ABNF.Util do
   @doc """
   Normalices a rule name. It will convert it to a String.t and also downcase it.
   """
-  @spec rulename(String.t|char_list) :: String.t
+  @spec rulename(String.t|charlist) :: String.t
   def rulename(name) when is_list(name) do
     rulename to_string(name)
   end

--- a/test/ex_abnf_test.exs
+++ b/test/ex_abnf_test.exs
@@ -574,7 +574,7 @@ defmodule ABNF_Test do
 
   test "sdp" do
     grammar = load "RFC4566"
-    data = to_char_list(File.read! "test/resources/sdp1.txt")
+    data = to_charlist(File.read! "test/resources/sdp1.txt")
     %Res{
       input: ^data,
       rest: '',
@@ -612,7 +612,7 @@ defmodule ABNF_Test do
 
   test "sip" do
     grammar = load "RFC3261"
-    data = to_char_list(File.read! "test/resources/sip1.txt")
+    data = to_charlist(File.read! "test/resources/sip1.txt")
     %Res{
       input: ^data,
       rest: '',

--- a/test/resources/RFC5322-no-obs.abnf
+++ b/test/resources/RFC5322-no-obs.abnf
@@ -47,13 +47,13 @@ date            =   day month year !!!
   {:ok, Map.put(state, :year, :lists.flatten(y))}
 !!!
 day             =   ([FWS] 1*2DIGIT FWS)  !!!
-  {:ok, state, to_char_list String.strip(to_string(rule))}
+  {:ok, state, to_charlist String.trim(to_string(rule))}
 !!!
 month           =   "Jan" / "Feb" / "Mar" / "Apr" /
                     "May" / "Jun" / "Jul" / "Aug" /
                     "Sep" / "Oct" / "Nov" / "Dec"
 year            =   (FWS 4*DIGIT FWS) !!!
-  {:ok, state, to_char_list String.strip(to_string(rule))}
+  {:ok, state, to_charlist String.trim(to_string(rule))}
 !!!
 time            =   time-of-day zone !!!
   [_, tz] = values
@@ -70,7 +70,7 @@ second          =   2DIGIT !!!
   {:ok, Map.put(state, :second, rule)}
 !!!
 zone            =   (FWS ( "+" / "-" ) 4DIGIT) !!!
-  {:ok, state, to_char_list String.strip(to_string(rule))}
+  {:ok, state, to_charlist String.trim(to_string(rule))}
 !!!
 address         =   mailbox / group
 mailbox         =   name-addr / addr-spec


### PR DESCRIPTION
This should fix the following deprecations and dialyzer warnings:

- some undefined types in the specs
- `to_char_list/1` and `String.strip/1` deprecations
- `char_list()` deprecated type
- the warning about unused variables in the generated code (`variable "string_values" is unused`, etc.)

The deprecated functions requires elixir 1.3, which should be fine i guess. It that's ok, the elixir version in `mix.exs` and the travis file should be updated too.