### PR TITLE
Update for elixir 1.8

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/lib/ex_abnf.ex
+++ b/lib/ex_abnf.ex
@@ -22,32 +22,33 @@ defmodule ABNF do
   alias ABNF.Interpreter, as: Interpreter
   alias ABNF.CaptureResult, as: CaptureResult
   require Logger
+
   @doc """
   Loads a set of abnf rules from a file.
   """
-  @spec load_file(String.t) :: Grammar.t | no_return
+  @spec load_file(String.t()) :: Grammar.t() | no_return
   def load_file(file) do
-    data = File.read! file
-    load to_char_list(data)
+    data = File.read!(file)
+    load(to_charlist(data))
   end
 
   @doc """
   Returns the abnf rules found in the given char list.
   """
-  @spec load([byte]) :: Grammar.t | no_return
+  @spec load([byte]) :: Grammar.t() | no_return
   def load(input) do
-    case Grammar.rulelist input do
+    case Grammar.rulelist(input) do
       {rules, ''} -> rules
-      {_rlist, rest} -> throw {:incomplete_parsing, rest}
-      _ -> throw {:invalid_grammar, input}
+      {_rlist, rest} -> throw({:incomplete_parsing, rest})
+      _ -> throw({:invalid_grammar, input})
     end
   end
 
   @doc """
   Parses an input given a gramar, looking for the given rule.
   """
-  @spec apply(Grammar.t, String.t, [byte], term) :: CaptureResult.t
+  @spec apply(Grammar.t(), String.t(), [byte], term) :: CaptureResult.t()
   def apply(grammar, rule, input, state \\ nil) do
-    Interpreter.apply grammar, rule, input, state
+    Interpreter.apply(grammar, rule, input, state)
   end
 end

--- a/lib/ex_abnf/capture_result.ex
+++ b/lib/ex_abnf/capture_result.ex
@@ -18,12 +18,18 @@ defmodule ABNF.CaptureResult do
       limitations under the License.
   """
 
-  defstruct input: '', # original input before match
-    rest: '',          # text that didn't match
-    string_text: '',   # full text that matched
-    string_tokens: [], # contains string parts that matched (usually 1)
-    values: nil,       # real rule value
-    state: nil         # state after match
+  # original input before match
+  defstruct input: '',
+            # text that didn't match
+            rest: '',
+            # full text that matched
+            string_text: '',
+            # contains string parts that matched (usually 1)
+            string_tokens: [],
+            # real rule value
+            values: nil,
+            # state after match
+            state: nil
 
   @type t :: %ABNF.CaptureResult{}
 end

--- a/lib/ex_abnf/core.ex
+++ b/lib/ex_abnf/core.ex
@@ -23,7 +23,7 @@ defmodule ABNF.Core do
   @spec alpha?(char) :: boolean
   def alpha?(char) do
     (char >= 0x41 and char <= 0x5A) or
-    (char >= 0x61 and char <= 0x7A)
+      (char >= 0x61 and char <= 0x7A)
   end
 
   @doc """
@@ -80,8 +80,8 @@ defmodule ABNF.Core do
   @spec hexdig?(char) :: boolean
   def hexdig?(char) do
     digit?(char) or
-    (char >= 0x41 and char <= 0x46) or
-    (char >= 0x61 and char <= 0x66)
+      (char >= 0x41 and char <= 0x46) or
+      (char >= 0x61 and char <= 0x66)
   end
 
   @doc """

--- a/lib/ex_abnf/grammar.ex
+++ b/lib/ex_abnf/grammar.ex
@@ -27,162 +27,216 @@ defmodule ABNF.Grammar do
   Builds a Grammar.t from the given input (an ABNF text grammar). You should
   never use this one directly but use the ones in the ABNF module instead.
   """
-  @spec rulelist(char_list) :: t
+  @spec rulelist(charlist) :: t
   def rulelist(input) do
-    {module_code, rest} = case code input do
-      nil -> {"", input}
-      {c, rest} -> {to_string(c), rest}
-    end
-    rulelist_tail module_code, rest
+    {module_code, rest} =
+      case code(input) do
+        nil -> {"", input}
+        {c, rest} -> {to_string(c), rest}
+      end
+
+    rulelist_tail(module_code, rest)
   end
 
   defp rulelist_tail(module_code, input, acc \\ %{}, last \\ nil) do
-    case rule input do
+    case rule(input) do
       nil ->
-        rest = zero_or_more_wsp input
-        case c_nl rest do
+        rest = zero_or_more_wsp(input)
+
+        case c_nl(rest) do
           nil ->
-            module_name = String.to_atom(
-              "A#{Base.encode16 :crypto.hash(
-                :md5, :erlang.term_to_binary(make_ref())
-              )}"
-            )
+            module_name =
+              String.to_atom(
+                "A#{
+                  Base.encode16(
+                    :crypto.hash(
+                      :md5,
+                      :erlang.term_to_binary(make_ref())
+                    )
+                  )
+                }"
+              )
 
-            acc = Enum.reduce acc, %{}, fn({k, v}, rules) ->
-              c = if is_nil v[:code] do
-                nil
-              else
-                fun_name = String.to_atom(
-                  String.downcase("A#{Base.encode16 :crypto.hash(
-                    :md5, :erlang.term_to_binary(make_ref())
-                  )}"
-                ))
-                {module_name, fun_name, v[:code]}
-              end
-              v = %{v | code: c}
-              Map.put rules, k, v
-            end
+            acc =
+              Enum.reduce(acc, %{}, fn {k, v}, rules ->
+                c =
+                  if is_nil(v[:code]) do
+                    nil
+                  else
+                    fun_name =
+                      String.to_atom(
+                        String.downcase(
+                          "A#{
+                            Base.encode16(
+                              :crypto.hash(
+                                :md5,
+                                :erlang.term_to_binary(make_ref())
+                              )
+                            )
+                          }"
+                        )
+                      )
 
-            funs = Enum.reduce acc, module_code, fn({_k, v}, str) ->
-              if is_nil v[:code] do
-                str
-              else
-                {_, f, c} = v[:code]
-                str = str <> "def #{f}(state, rule, string_values, values) do\r\n"
-                str = str <> "\t#{c}\r\n"
-                str = str <> "end\r\n"
-                str
-              end
-            end
+                    {module_name, fun_name, v[:code]}
+                  end
+
+                v = %{v | code: c}
+                Map.put(rules, k, v)
+              end)
+
+            funs =
+              Enum.reduce(acc, module_code, fn {_k, v}, str ->
+                if is_nil(v[:code]) do
+                  str
+                else
+                  {_, f, c} = v[:code]
+                  str = str <> "def #{f}(state, rule, string_values, values) do\r\n"
+                  str = str <> "\t#{c}\r\n"
+                  str = str <> "end\r\n"
+                  str
+                end
+              end)
+
             funs = Code.string_to_quoted(funs)
-            Module.create module_name, funs, Macro.Env.location(__ENV__)
+            Module.create(module_name, funs, Macro.Env.location(__ENV__))
             {acc, input}
-          {comments, rest} -> case last do
-            nil -> rulelist_tail module_code, rest, acc
-            last ->
-              last = add_comments last, comments
-              rulelist_tail module_code, rest, Map.put(acc, last.name, last)
-          end
+
+          {comments, rest} ->
+            case last do
+              nil ->
+                rulelist_tail(module_code, rest, acc)
+
+              last ->
+                last = add_comments(last, comments)
+                rulelist_tail(module_code, rest, Map.put(acc, last.name, last))
+            end
         end
-      {r, rest} -> rulelist_tail module_code, rest, Map.put(acc, r.name, r)
+
+      {r, rest} ->
+        rulelist_tail(module_code, rest, Map.put(acc, r.name, r))
     end
   end
 
   # rule = rulename defined-as elements c-nl
   # ; continues if next line starts with white space
   defp rule(input) do
-    case rulename input do
-      nil -> nil
-      {name, rest} -> case defined_as rest do
-        nil -> nil
-        {das, rest} -> case elements rest do
-          nil -> nil
-          {es, rest} ->
-            {c, rest} = case code rest do
-              nil -> {nil, rest}
-              r -> r
-            end
-            case c_nl rest do
-              nil -> nil
-              {comments, rest} ->
-                r = %{
-                  name: Util.rulename(name.value),
-                  defined_as: das,
-                  element: :rule,
-                  value: es,
-                  code: c,
-                  comments: comments
-                }
-                {r, rest}
+    case rulename(input) do
+      nil ->
+        nil
+
+      {name, rest} ->
+        case defined_as(rest) do
+          nil ->
+            nil
+
+          {das, rest} ->
+            case elements(rest) do
+              nil ->
+                nil
+
+              {es, rest} ->
+                {c, rest} =
+                  case code(rest) do
+                    nil -> {nil, rest}
+                    r -> r
+                  end
+
+                case c_nl(rest) do
+                  nil ->
+                    nil
+
+                  {comments, rest} ->
+                    r = %{
+                      name: Util.rulename(name.value),
+                      defined_as: das,
+                      element: :rule,
+                      value: es,
+                      code: c,
+                      comments: comments
+                    }
+
+                    {r, rest}
+                end
             end
         end
-      end
     end
   end
 
   # defined-as = *c-wsp ("=" / "=/") *c-wsp
   # ; basic rules definition and incremental alternatives
   defp defined_as(input) do
-    case zero_or_more_cwsp input do
-      {_, [?=, ?/|_rest]} ->
+    case zero_or_more_cwsp(input) do
+      {_, [?=, ?/ | _rest]} ->
         raise RuntimeError, "Incremental alternatives are not yet supported"
-        #{_, rest} = zero_or_more_cwsp rest
-        #{:alternative, rest}
-      {_, [?=|rest]} ->
-        {_, rest} = zero_or_more_cwsp rest
+
+      # {_, rest} = zero_or_more_cwsp rest
+      # {:alternative, rest}
+      {_, [?= | rest]} ->
+        {_, rest} = zero_or_more_cwsp(rest)
         {:equal, rest}
-      _ -> nil
+
+      _ ->
+        nil
     end
   end
 
   # code = !!! octet !!!
   defp code(input) do
     case input do
-      [?!,?!,?!|rest] -> code_tail rest
+      [?!, ?!, ?! | rest] -> code_tail(rest)
       _ -> nil
     end
   end
 
   defp code_tail(input, acc \\ []) do
     case input do
-      [?!,?!,?!|rest] -> {Enum.reverse(acc), rest}
-      [char|rest] -> code_tail rest, [char|acc]
+      [?!, ?!, ?! | rest] -> {Enum.reverse(acc), rest}
+      [char | rest] -> code_tail(rest, [char | acc])
       _ -> nil
     end
   end
 
   # alternation = concatenation *(*c-wsp "/" *c-wsp concatenation)
   defp alternation(input) do
-    case concatenation input do
-      nil -> nil
+    case concatenation(input) do
+      nil ->
+        nil
+
       {c, rest} ->
-        {as, rest} = alternation_tail rest, [c]
+        {as, rest} = alternation_tail(rest, [c])
         {token(:alternation, as), rest}
     end
   end
 
-  defp alternation_tail(input, [last_e|next_e] = acc) do
-    case zero_or_more_cwsp input do
-      {comments1, [?/|rest]} ->
-        {comments2, rest} = zero_or_more_cwsp rest
-        case concatenation rest do
-          nil -> {Enum.reverse(acc), input}
+  defp alternation_tail(input, [last_e | next_e] = acc) do
+    case zero_or_more_cwsp(input) do
+      {comments1, [?/ | rest]} ->
+        {comments2, rest} = zero_or_more_cwsp(rest)
+
+        case concatenation(rest) do
+          nil ->
+            {Enum.reverse(acc), input}
+
           {c, rest} ->
-            c = add_comments c, comments2
-            last_e = add_comments last_e, comments1
-            alternation_tail rest, [c, last_e|next_e]
+            c = add_comments(c, comments2)
+            last_e = add_comments(last_e, comments1)
+            alternation_tail(rest, [c, last_e | next_e])
         end
-      _ -> {Enum.reverse(acc), input}
+
+      _ ->
+        {Enum.reverse(acc), input}
     end
   end
 
   # repetition = [repeat] element
   defp repetition(input) do
-    {from, to, rest} = case repeat input do
-      nil -> {1, 1, input}
-      r -> r
-    end
-    case element rest do
+    {from, to, rest} =
+      case repeat(input) do
+        nil -> {1, 1, input}
+        r -> r
+      end
+
+    case element(rest) do
       nil -> nil
       {e, rest} -> {token(:repetition, %{from: from, to: to, value: e}), rest}
     end
@@ -190,24 +244,29 @@ defmodule ABNF.Grammar do
 
   # concatenation = repetition *(1*c-wsp repetition)
   defp concatenation(input) do
-    case repetition input do
-      nil -> nil
+    case repetition(input) do
+      nil ->
+        nil
+
       {e, rest} ->
-        {es, rest} = concatenation_tail rest, [e]
+        {es, rest} = concatenation_tail(rest, [e])
         {token(:concatenation, es), rest}
     end
   end
 
-  defp concatenation_tail(input, [last_e|next_e] = acc) do
-    {match, rest} = zero_or_more_cwsp input
+  defp concatenation_tail(input, [last_e | next_e] = acc) do
+    {match, rest} = zero_or_more_cwsp(input)
+
     if length(match) === 0 do
       {Enum.reverse(acc), input}
     else
-      case repetition rest do
-        nil -> {Enum.reverse(acc), input}
+      case repetition(rest) do
+        nil ->
+          {Enum.reverse(acc), input}
+
         {e, rest} ->
-          last_e = add_comments last_e, match
-          concatenation_tail rest, [e, last_e|next_e]
+          last_e = add_comments(last_e, match)
+          concatenation_tail(rest, [e, last_e | next_e])
       end
     end
   end
@@ -215,71 +274,103 @@ defmodule ABNF.Grammar do
   # elements = alternation *WSP
   # As described in the Errata #2968
   defp elements(input) do
-    case alternation input do
-      nil -> nil
+    case alternation(input) do
+      nil ->
+        nil
+
       {a, rest} ->
-        rest = zero_or_more_wsp rest
+        rest = zero_or_more_wsp(rest)
         {a, rest}
     end
   end
 
   # element = rulename / group / option / char-val / num-val / prose-val
   defp element(input) do
-    case rulename input do
-      nil -> case group input do
-        nil -> case option input do
-          nil -> case char_val input do
-            nil -> case num_val input do
-              nil -> prose_val input
-              r -> r
+    case rulename(input) do
+      nil ->
+        case group(input) do
+          nil ->
+            case option(input) do
+              nil ->
+                case char_val(input) do
+                  nil ->
+                    case num_val(input) do
+                      nil -> prose_val(input)
+                      r -> r
+                    end
+
+                  r ->
+                    r
+                end
+
+              r ->
+                r
             end
-            r -> r
-          end
-          r -> r
+
+          r ->
+            r
         end
-        r -> r
-      end
-      r -> r
+
+      r ->
+        r
     end
   end
 
   # group = "(" *c-wsp alternation *c-wsp ")"
   defp group(input) do
     case input do
-      [?(|rest] ->
-        {comments1, rest} = zero_or_more_cwsp rest
-        case alternation rest do
-          nil -> nil
+      [?( | rest] ->
+        {comments1, rest} = zero_or_more_cwsp(rest)
+
+        case alternation(rest) do
+          nil ->
+            nil
+
           {a, rest} ->
-            case zero_or_more_cwsp rest do
-              {comments2, [?)|rest]} ->
-                a = add_comments a, (comments1 ++ comments2)
+            case zero_or_more_cwsp(rest) do
+              {comments2, [?) | rest]} ->
+                a = add_comments(a, comments1 ++ comments2)
                 {token(:group, a), rest}
-              _ -> nil
+
+              _ ->
+                nil
             end
-          _ -> nil
+
+          _ ->
+            nil
         end
-      _ -> nil
+
+      _ ->
+        nil
     end
   end
 
   # option = "[" *c-wsp alternation *c-wsp "]"
   defp option(input) do
     case input do
-      [?[|rest] ->
-        {comments1, rest} = zero_or_more_cwsp rest
-        case alternation rest do
-          nil -> nil
+      [?[ | rest] ->
+        {comments1, rest} = zero_or_more_cwsp(rest)
+
+        case alternation(rest) do
+          nil ->
+            nil
+
           {a, rest} ->
-            case zero_or_more_cwsp rest do
-              {comments2, [?]|rest]} ->
-                a = add_comments a, (comments1 ++ comments2)
+            case zero_or_more_cwsp(rest) do
+              {comments2, [?] | rest]} ->
+                a = add_comments(a, comments1 ++ comments2)
                 {token(:option, a), rest}
-              _ -> nil
+
+              _ ->
+                nil
             end
-          _ -> nil
+
+          _ ->
+            nil
         end
-      _ -> nil
+
+      _ ->
+        nil
     end
   end
 
@@ -289,127 +380,161 @@ defmodule ABNF.Grammar do
   # refer to the same rule.
   defp rulename(input) do
     case input do
-      [char|rest] -> if Core.alpha?(char) do
-        rulename_tail rest, [char]
-      else
+      [char | rest] ->
+        if Core.alpha?(char) do
+          rulename_tail(rest, [char])
+        else
+          nil
+        end
+
+      _ ->
         nil
-      end
-      _ -> nil
     end
   end
 
   defp rulename_tail(input, acc) do
     case input do
-      [char|rest] -> if Core.alpha?(char) or Core.digit?(char) or (char === ?-) do
-        rulename_tail rest, [char|acc]
-      else
+      [char | rest] ->
+        if Core.alpha?(char) or Core.digit?(char) or char === ?- do
+          rulename_tail(rest, [char | acc])
+        else
+          {token(:rulename, Util.rulename(Enum.reverse(acc))), input}
+        end
+
+      _ ->
         {token(:rulename, Util.rulename(Enum.reverse(acc))), input}
-      end
-      _ -> {token(:rulename, Util.rulename(Enum.reverse(acc))), input}
     end
   end
 
   # repeat = 1*DIGIT / (*DIGIT "*" *DIGIT)
   defp repeat(input) do
-    case num input, 10 do
-      {from, [?*|rest]} -> case num rest, 10 do
-        {to, rest} -> {from, to, rest}
-        _ -> {from, :infinity, rest}
-      end
-      {from, rest} -> {from, from, rest}
-      nil -> case input do
-        [?*|rest] -> case num rest, 10 do
-          nil -> {0, :infinity, rest}
-          {to, rest} -> {0, to, rest}
+    case num(input, 10) do
+      {from, [?* | rest]} ->
+        case num(rest, 10) do
+          {to, rest} -> {from, to, rest}
+          _ -> {from, :infinity, rest}
         end
-        _ -> nil
-      end
+
+      {from, rest} ->
+        {from, from, rest}
+
+      nil ->
+        case input do
+          [?* | rest] ->
+            case num(rest, 10) do
+              nil -> {0, :infinity, rest}
+              {to, rest} -> {0, to, rest}
+            end
+
+          _ ->
+            nil
+        end
     end
   end
 
   # *WSP
   defp zero_or_more_wsp(input) do
     case input do
-      [char|rest] -> if Core.wsp?(char) do
-        zero_or_more_wsp rest
-      else
+      [char | rest] ->
+        if Core.wsp?(char) do
+          zero_or_more_wsp(rest)
+        else
+          input
+        end
+
+      _ ->
         input
-      end
-      _ -> input
     end
   end
 
   # *c-wsp
   defp zero_or_more_cwsp(input, acc \\ []) do
-    case c_wsp input do
+    case c_wsp(input) do
       nil -> {:lists.flatten(Enum.reverse(acc)), input}
-      {match, rest} -> zero_or_more_cwsp rest, [match|acc]
+      {match, rest} -> zero_or_more_cwsp(rest, [match | acc])
     end
   end
 
   # c-wsp = WSP / (c-nl WSP)
   defp c_wsp(input) do
     case input do
-      [char|rest] -> if Core.wsp? char do
-        {[char], rest}
-      else
-        c_nl_wsp input
-      end
-      _ -> nil
+      [char | rest] ->
+        if Core.wsp?(char) do
+          {[char], rest}
+        else
+          c_nl_wsp(input)
+        end
+
+      _ ->
+        nil
     end
   end
 
   # c-nl WSP
   defp c_nl_wsp(input) do
-    case c_nl input do
-      nil -> nil
-      {match, [char|rest]} -> if Core.wsp? char do
-        {match ++ [char], rest}
-      else
+    case c_nl(input) do
+      nil ->
         nil
-      end
-      _ -> nil
+
+      {match, [char | rest]} ->
+        if Core.wsp?(char) do
+          {match ++ [char], rest}
+        else
+          nil
+        end
+
+      _ ->
+        nil
     end
   end
 
   # c-nl = comment / CRLF ; comment or newline
   defp c_nl(input) do
-    case comment input do
-      nil -> case crlf input do
-        nil -> nil
-        r -> r
-      end
-      r -> r
+    case comment(input) do
+      nil ->
+        case crlf(input) do
+          nil -> nil
+          r -> r
+        end
+
+      r ->
+        r
     end
   end
 
   # comment = ";" *(WSP / VCHAR) CRLF
   defp comment(input) do
     case input do
-      [?;|rest] -> comment_tail rest
+      [?; | rest] -> comment_tail(rest)
       _ -> nil
     end
   end
 
   defp comment_tail(input, acc \\ []) do
     case crlf(input) do
-      nil -> case input do
-        [char|rest] -> if Core.wsp?(char) or Core.vchar?(char) do
-          comment_tail rest, [char|acc]
-        else
-          nil
+      nil ->
+        case input do
+          [char | rest] ->
+            if Core.wsp?(char) or Core.vchar?(char) do
+              comment_tail(rest, [char | acc])
+            else
+              nil
+            end
+
+          _ ->
+            nil
         end
-        _ -> nil
-      end
-      {match, rest} -> {Enum.reverse(acc) ++ match, rest}
+
+      {match, rest} ->
+        {Enum.reverse(acc) ++ match, rest}
     end
   end
 
   # From RFC7405:
   # char-val = case-insensitive-string / case-sensitive-string
   defp char_val(input) do
-    case case_insensitive_string input do
-      nil -> case_sensitive_string input
+    case case_insensitive_string(input) do
+      nil -> case_sensitive_string(input)
       r -> r
     end
   end
@@ -434,18 +559,21 @@ defmodule ABNF.Grammar do
   # individually.
   defp case_insensitive_string(input) do
     case input do
-      [?%, char|rest] -> if char === ?i or char === ?I do
-        case quoted_string rest do
-          nil -> nil
-          {{l, str}, rest} -> char_val_token rest, l, str, [:caseless]
+      [?%, char | rest] ->
+        if char === ?i or char === ?I do
+          case quoted_string(rest) do
+            nil -> nil
+            {{l, str}, rest} -> char_val_token(rest, l, str, [:caseless, :unicode])
+          end
+        else
+          nil
         end
-      else
-        nil
-      end
-      _ -> case quoted_string input do
-        nil -> nil
-        {{l, str}, rest} -> char_val_token rest, l, str, [:caseless]
-      end
+
+      _ ->
+        case quoted_string(input) do
+          nil -> nil
+          {{l, str}, rest} -> char_val_token(rest, l, str, [:caseless, :unicode])
+        end
     end
   end
 
@@ -453,20 +581,24 @@ defmodule ABNF.Grammar do
   # case-sensitive-string = "%s" quoted-string
   defp case_sensitive_string(input) do
     case input do
-      [?%, char|rest] -> if char === ?s or char === ?S do
-        case quoted_string rest do
-          nil -> nil
-          {{l, str}, rest} -> char_val_token rest, l, str
+      [?%, char | rest] ->
+        if char === ?s or char === ?S do
+          case quoted_string(rest) do
+            nil -> nil
+            {{l, str}, rest} -> char_val_token(rest, l, str)
+          end
+        else
+          nil
         end
-      else
+
+      _ ->
         nil
-      end
-      _ -> nil
     end
   end
 
-  defp char_val_token(rest, length, str, options \\ []) do
-    {:ok, r} = :re.compile [?^, str], options
+  defp char_val_token(rest, length, str, options \\ [:unicode]) do
+    {:ok, r} = :re.compile([?^, str], options)
+
     {
       token(:char_val, %{
         regex: r,
@@ -481,34 +613,41 @@ defmodule ABNF.Grammar do
   # ; quoted string of SP and VCHAR without DQUOTE
   defp quoted_string(input) do
     case input do
-      [char|rest] -> if Core.dquote? char do
-        quoted_string_tail rest
-      else
+      [char | rest] ->
+        if Core.dquote?(char) do
+          quoted_string_tail(rest)
+        else
+          nil
+        end
+
+      [] ->
         nil
-      end
-      [] -> nil
     end
   end
 
   defp quoted_string_tail(input, acc \\ {0, []}) do
     {l, acc_char} = acc
+
     case input do
-      [char|rest] ->
+      [char | rest] ->
         if((char >= 0x20 and char <= 0x21) or (char >= 0x23 and char <= 0x7E)) do
           escape = not (Core.alpha?(char) or Core.digit?(char))
+
           if escape do
-            quoted_string_tail rest, {l + 1, [char, 92|acc_char]}
+            quoted_string_tail(rest, {l + 1, [char, 92 | acc_char]})
           else
-            quoted_string_tail rest, {l + 1, [char|acc_char]}
+            quoted_string_tail(rest, {l + 1, [char | acc_char]})
           end
         else
-          if Core.dquote? char do
+          if Core.dquote?(char) do
             {{l, Enum.reverse(acc_char)}, rest}
           else
             nil
           end
         end
-      _ -> nil
+
+      _ ->
+        nil
     end
   end
 
@@ -522,57 +661,76 @@ defmodule ABNF.Grammar do
   # hex-val = "x" 1*HEXDIG [ 1*("." 1*HEXDIG) / ("-" 1*HEXDIG) ]
   defp num_val(input) do
     case input do
-      [?%, type|rest] -> cond do
-        (type === ?b or type === ?B) -> num_val_tail rest, 2
-        (type === ?d or type === ?D) -> num_val_tail rest, 10
-        (type === ?x or type === ?X) -> num_val_tail rest, 16
-        true -> nil
-      end
-      _ -> nil
+      [?%, type | rest] ->
+        cond do
+          type === ?b or type === ?B -> num_val_tail(rest, 2)
+          type === ?d or type === ?D -> num_val_tail(rest, 10)
+          type === ?x or type === ?X -> num_val_tail(rest, 16)
+          true -> nil
+        end
+
+      _ ->
+        nil
     end
   end
 
   defp num_val_tail(input, base) do
-    case num input, base do
-      nil -> nil
-      {n, [?.|_] = rest} -> num_concat_tail rest, base, [n]
-      {from, [?-|rest]} -> case num rest, base do
-        nil -> nil
-        {to, rest} -> {token(:num_range, %{from: from, to: to}), rest}
-      end
-      {n, rest} -> {token(:num_range, %{from: n, to: n}), rest}
+    case num(input, base) do
+      nil ->
+        nil
+
+      {n, [?. | _] = rest} ->
+        num_concat_tail(rest, base, [n])
+
+      {from, [?- | rest]} ->
+        case num(rest, base) do
+          nil -> nil
+          {to, rest} -> {token(:num_range, %{from: from, to: to}), rest}
+        end
+
+      {n, rest} ->
+        {token(:num_range, %{from: n, to: n}), rest}
     end
   end
 
   defp num_concat_tail(input, base, acc) do
     case input do
-      [?.|rest] -> case num rest, base do
-        nil -> {token(:num_concat, Enum.reverse(acc)), input}
-        {n, rest} -> num_concat_tail rest, base, [n|acc]
-      end
-      _ -> {token(:num_concat, Enum.reverse(acc)), input}
+      [?. | rest] ->
+        case num(rest, base) do
+          nil -> {token(:num_concat, Enum.reverse(acc)), input}
+          {n, rest} -> num_concat_tail(rest, base, [n | acc])
+        end
+
+      _ ->
+        {token(:num_concat, Enum.reverse(acc)), input}
     end
   end
 
   defp num(input, base) do
     case input do
-      [char|rest] -> if is_num? char, base do
-        num_tail rest, base, [char]
-      else
+      [char | rest] ->
+        if is_num?(char, base) do
+          num_tail(rest, base, [char])
+        else
+          nil
+        end
+
+      _ ->
         nil
-      end
-      _ -> nil
     end
   end
 
   defp num_tail(input, base, acc) do
     case input do
-      [char|rest] -> if is_num? char, base do
-        num_tail rest, base, [char|acc]
-      else
+      [char | rest] ->
+        if is_num?(char, base) do
+          num_tail(rest, base, [char | acc])
+        else
+          {to_i(Enum.reverse(acc), base), input}
+        end
+
+      _ ->
         {to_i(Enum.reverse(acc), base), input}
-      end
-      _ -> {to_i(Enum.reverse(acc), base), input}
     end
   end
 
@@ -581,29 +739,36 @@ defmodule ABNF.Grammar do
   # to be used as last resort
   defp prose_val(input) do
     case input do
-      [?<|rest] -> case prose_val_tail rest do
-        nil -> nil
-        {value, rest} -> {token(:rulename, Util.rulename(value)), rest}
-      end
-      _ -> nil
+      [?< | rest] ->
+        case prose_val_tail(rest) do
+          nil -> nil
+          {value, rest} -> {token(:rulename, Util.rulename(value)), rest}
+        end
+
+      _ ->
+        nil
     end
   end
 
   defp prose_val_tail(input, acc \\ []) do
     case input do
-      [?>|rest] -> {Enum.reverse(acc), rest}
-      [char|rest] ->
+      [?> | rest] ->
+        {Enum.reverse(acc), rest}
+
+      [char | rest] ->
         if((char >= 0x20 and char <= 0x3D) or (char >= 0x3F and char <= 0x7E)) do
-          prose_val_tail rest, [char|acc]
+          prose_val_tail(rest, [char | acc])
         else
           nil
         end
-      _ -> nil
+
+      _ ->
+        nil
     end
   end
 
   defp add_comments(t, comments) do
-    Map.put t, :comments, (t.comments ++ comments)
+    Map.put(t, :comments, t.comments ++ comments)
   end
 
   defp token(type, value, comments \\ []) do
@@ -617,29 +782,33 @@ defmodule ABNF.Grammar do
 
   defp crlf(input) do
     case input do
-      [char1, char2|rest] ->
+      [char1, char2 | rest] ->
         cond do
           Core.cr?(char1) and Core.lf?(char2) ->
             {[char1, char2], rest}
+
           Core.cr?(char1) == false and Core.lf?(char2) ->
-            raise ArgumentError, message: "Lines should end with CRLF [13,10], found [#{char1},#{char2}]"
+            raise ArgumentError,
+              message: "Lines should end with CRLF [13,10], found [#{char1},#{char2}]"
+
           true ->
             nil
         end
-      _ -> nil
+
+      _ ->
+        nil
     end
   end
 
   defp to_i(input, base) do
-    String.to_integer to_string(input), base
+    String.to_integer(to_string(input), base)
   end
 
   defp is_num?(char, base) do
     case base do
-      2 -> Core.bit? char
-      10 -> Core.digit? char
-      16 -> Core.hexdig? char
+      2 -> Core.bit?(char)
+      10 -> Core.digit?(char)
+      16 -> Core.hexdig?(char)
     end
   end
 end
-

--- a/lib/ex_abnf/util.ex
+++ b/lib/ex_abnf/util.ex
@@ -21,12 +21,12 @@ defmodule ABNF.Util do
   @doc """
   Normalices a rule name. It will convert it to a String.t and also downcase it.
   """
-  @spec rulename(String.t|char_list) :: String.t
+  @spec rulename(String.t() | charlist) :: String.t()
   def rulename(name) when is_list(name) do
-    rulename to_string(name)
+    rulename(to_string(name))
   end
 
   def rulename(name) when is_binary(name) do
-    String.downcase name
+    String.downcase(name)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,14 +2,16 @@ defmodule ABNF.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :ex_abnf,
-     name: "ex_abnf",
-     source_url: "https://github.com/marcelog/ex_abnf",
-     version: "0.3.0",
-     elixir: ">= 1.0.0",
-     description: description(),
-     package: package(),
-     deps: deps()]
+    [
+      app: :ex_abnf,
+      name: "ex_abnf",
+      source_url: "https://github.com/marcelog/ex_abnf",
+      version: "0.3.0",
+      elixir: ">= 1.0.0",
+      description: description(),
+      package: package(),
+      deps: deps()
+    ]
   end
 
   def application do
@@ -18,8 +20,8 @@ defmodule ABNF.Mixfile do
 
   defp deps do
     [
-      {:earmark, "~> 1.0.3", only: :dev},
-      {:ex_doc, "~> 0.14.5", only: :dev}
+      {:earmark, "~> 1.3", only: :dev},
+      {:ex_doc, "~> 0.20", only: :dev}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,7 @@
-%{"earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}
+%{
+  "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
+}

--- a/test/ex_abnf_test.exs
+++ b/test/ex_abnf_test.exs
@@ -26,17 +26,9 @@ defmodule ABNF_Test do
   end
 
   test "can do case (in)sensitive matches - RFC7405" do
-    grammar = load "RFC7405"
+    grammar = load("RFC7405")
 
-    nil = ABNF.apply grammar, "case-sensitive", 'abc', nil
-    %Res{
-      input: 'aBc',
-      rest: '',
-      string_text: 'aBc',
-      string_tokens: ['aBc'],
-      state: nil,
-      values: _
-    } = ABNF.apply grammar, "case-sensitive", 'aBc', nil
+    nil = ABNF.apply(grammar, "case-sensitive", 'abc', nil)
 
     %Res{
       input: 'aBc',
@@ -45,7 +37,7 @@ defmodule ABNF_Test do
       string_tokens: ['aBc'],
       state: nil,
       values: _
-    } = ABNF.apply grammar, "case-insensitive-1", 'aBc', nil
+    } = ABNF.apply(grammar, "case-sensitive", 'aBc', nil)
 
     %Res{
       input: 'aBc',
@@ -54,11 +46,21 @@ defmodule ABNF_Test do
       string_tokens: ['aBc'],
       state: nil,
       values: _
-    } = ABNF.apply grammar, "case-insensitive-2", 'aBc', nil
+    } = ABNF.apply(grammar, "case-insensitive-1", 'aBc', nil)
+
+    %Res{
+      input: 'aBc',
+      rest: '',
+      string_text: 'aBc',
+      string_tokens: ['aBc'],
+      state: nil,
+      values: _
+    } = ABNF.apply(grammar, "case-insensitive-2", 'aBc', nil)
   end
 
   test "can write module code" do
-    grammar = load "module_code"
+    grammar = load("module_code")
+
     %Res{
       input: '1.2.3.4rest',
       rest: 'rest',
@@ -66,11 +68,11 @@ defmodule ABNF_Test do
       string_tokens: ['1', '.', '2', '.', '3', '.', '4'],
       state: %{ipv4address: '1.2.3.4'},
       values: ["Your ip address is: 1.2.3.4"]
-    } = ABNF.apply grammar, "ipv4address", '1.2.3.4rest', %{}
+    } = ABNF.apply(grammar, "ipv4address", '1.2.3.4rest', %{})
   end
 
   test "ipv4" do
-    grammar = load "ipv4"
+    grammar = load("ipv4")
 
     %Res{
       input: '1.2.3.4rest',
@@ -79,7 +81,7 @@ defmodule ABNF_Test do
       string_tokens: ['1', '.', '2', '.', '3', '.', '4'],
       state: %{ipv4address: '1.2.3.4'},
       values: ["Your ip address is: 1.2.3.4"]
-    } = ABNF.apply grammar, "ipv4address", '1.2.3.4rest', %{}
+    } = ABNF.apply(grammar, "ipv4address", '1.2.3.4rest', %{})
 
     %Res{
       input: '192.168.0.1rest',
@@ -88,7 +90,7 @@ defmodule ABNF_Test do
       string_tokens: ['192', '.', '168', '.', '0', '.', '1'],
       state: %{ipv4address: '192.168.0.1'},
       values: ["Your ip address is: 192.168.0.1"]
-    } = ABNF.apply grammar, "ipv4address", '192.168.0.1rest', %{}
+    } = ABNF.apply(grammar, "ipv4address", '192.168.0.1rest', %{})
 
     %Res{
       input: '255.255.255.255rest',
@@ -97,13 +99,14 @@ defmodule ABNF_Test do
       string_tokens: ['255', '.', '255', '.', '255', '.', '255'],
       state: %{ipv4address: '255.255.255.255'},
       values: ["Your ip address is: 255.255.255.255"]
-    } = ABNF.apply grammar, "ipv4address", '255.255.255.255rest', %{}
+    } = ABNF.apply(grammar, "ipv4address", '255.255.255.255rest', %{})
 
-    nil = ABNF.apply grammar, "ipv4address", '255.255.256.255rest', %{}
+    nil = ABNF.apply(grammar, "ipv4address", '255.255.256.255rest', %{})
   end
 
   test "medium complexity" do
-    grammar = load "path"
+    grammar = load("path")
+
     %Res{
       input: 'segment',
       rest: '',
@@ -111,7 +114,7 @@ defmodule ABNF_Test do
       string_tokens: ['s', 'egment'],
       state: ['segment'],
       values: _
-    } = ABNF.apply grammar, "segment", 'segment', []
+    } = ABNF.apply(grammar, "segment", 'segment', [])
 
     %Res{
       input: '/a',
@@ -120,7 +123,7 @@ defmodule ABNF_Test do
       string_tokens: ['/a'],
       state: ['a'],
       values: _
-    } = ABNF.apply grammar, "path", '/a', []
+    } = ABNF.apply(grammar, "path", '/a', [])
 
     %Res{
       input: '/aa/bb',
@@ -129,11 +132,12 @@ defmodule ABNF_Test do
       string_tokens: ['/aa/bb'],
       state: ['aa', 'bb'],
       values: _
-    } = ABNF.apply grammar, "path", '/aa/bb', []
+    } = ABNF.apply(grammar, "path", '/aa/bb', [])
   end
 
   test "basic repetition and optional" do
-    grammar = load "basic"
+    grammar = load("basic")
+
     %Res{
       input: 'helloworld rest',
       rest: ' rest',
@@ -141,7 +145,7 @@ defmodule ABNF_Test do
       string_tokens: ['helloworld'],
       state: nil,
       values: _
-    } = ABNF.apply grammar, "string1", 'helloworld rest', nil
+    } = ABNF.apply(grammar, "string1", 'helloworld rest', nil)
 
     %Res{
       input: 'helloworld rest',
@@ -150,7 +154,7 @@ defmodule ABNF_Test do
       string_tokens: ['hel'],
       state: nil,
       values: _
-    } = ABNF.apply grammar, "string2", 'helloworld rest', nil
+    } = ABNF.apply(grammar, "string2", 'helloworld rest', nil)
 
     %Res{
       input: 'helloworld rest',
@@ -159,7 +163,7 @@ defmodule ABNF_Test do
       string_tokens: ['he'],
       state: nil,
       values: _
-    } = ABNF.apply grammar, "string3", 'helloworld rest', nil
+    } = ABNF.apply(grammar, "string3", 'helloworld rest', nil)
 
     %Res{
       input: 'helloworld rest',
@@ -168,7 +172,7 @@ defmodule ABNF_Test do
       string_tokens: ['helloworld'],
       state: nil,
       values: _
-    } = ABNF.apply grammar, "string4", 'helloworld rest', nil
+    } = ABNF.apply(grammar, "string4", 'helloworld rest', nil)
 
     %Res{
       input: '3helloworld rest',
@@ -177,7 +181,7 @@ defmodule ABNF_Test do
       string_tokens: ['3', 'helloworld'],
       state: nil,
       values: _
-    } = ABNF.apply grammar, "string5", '3helloworld rest', nil
+    } = ABNF.apply(grammar, "string5", '3helloworld rest', nil)
 
     %Res{
       input: 'helloworld rest',
@@ -186,11 +190,11 @@ defmodule ABNF_Test do
       string_tokens: ['', 'helloworld'],
       state: nil,
       values: _
-    } = ABNF.apply grammar, "string5", 'helloworld rest', nil
+    } = ABNF.apply(grammar, "string5", 'helloworld rest', nil)
   end
 
   test "ipv6" do
-    grammar = load "ipv6"
+    grammar = load("ipv6")
 
     addresses = [
       '::',
@@ -391,21 +395,23 @@ defmodule ABNF_Test do
       'a:b:c:d:e:f:0::'
     ]
 
-    Enum.each addresses, fn(a) ->
-      Logger.debug "Testing IPv6: #{inspect a}"
+    Enum.each(addresses, fn a ->
+      Logger.debug("Testing IPv6: #{inspect(a)}")
       string = a ++ 'rest'
+
       %Res{
         input: ^string,
         rest: 'rest',
         string_text: ^a,
         state: %{}
-      } = ABNF.apply grammar, "ipv6address", string, %{}
-    end
+      } = ABNF.apply(grammar, "ipv6address", string, %{})
+    end)
   end
 
   test "uri" do
-    grammar = load "RFC3986"
+    grammar = load("RFC3986")
     url = 'http://user:pass@host.com:421/some/path?k1=v1&k2=v2#one_fragment'
+
     %Res{
       input: ^url,
       rest: '',
@@ -429,9 +435,10 @@ defmodule ABNF_Test do
         '#one_fragment'
       ],
       values: _
-    } = ABNF.apply grammar, "uri", url, %{segments: []}
+    } = ABNF.apply(grammar, "uri", url, %{segments: []})
 
     url = 'http:/path'
+
     %Res{
       input: ^url,
       rest: '',
@@ -443,9 +450,10 @@ defmodule ABNF_Test do
       string_text: ^url,
       string_tokens: ['http', ':', '/path', '', ''],
       values: _
-    } = ABNF.apply grammar, "uri", url, %{segments: []}
+    } = ABNF.apply(grammar, "uri", url, %{segments: []})
 
     url = 'http://a.com'
+
     %Res{
       input: ^url,
       rest: '',
@@ -458,9 +466,10 @@ defmodule ABNF_Test do
       string_text: ^url,
       string_tokens: ['http', ':', '//a.com', '', ''],
       values: _
-    } = ABNF.apply grammar, "uri", url, %{segments: []}
+    } = ABNF.apply(grammar, "uri", url, %{segments: []})
 
     url = 'http://a.com:789'
+
     %Res{
       input: ^url,
       rest: '',
@@ -474,9 +483,10 @@ defmodule ABNF_Test do
       string_text: ^url,
       string_tokens: ['http', ':', '//a.com:789', '', ''],
       values: _
-    } = ABNF.apply grammar, "uri", url, %{segments: []}
+    } = ABNF.apply(grammar, "uri", url, %{segments: []})
 
     url = 'http://192.168.0.1/path'
+
     %Res{
       input: ^url,
       rest: '',
@@ -490,9 +500,10 @@ defmodule ABNF_Test do
       string_text: ^url,
       string_tokens: ['http', ':', '//192.168.0.1/path', '', ''],
       values: _
-    } = ABNF.apply grammar, "uri", url, %{segments: []}
+    } = ABNF.apply(grammar, "uri", url, %{segments: []})
 
     url = 'http:'
+
     %Res{
       input: ^url,
       rest: '',
@@ -503,9 +514,10 @@ defmodule ABNF_Test do
       string_text: ^url,
       string_tokens: ['http', ':', '', '', ''],
       values: _
-    } = ABNF.apply grammar, "uri", url, %{segments: []}
+    } = ABNF.apply(grammar, "uri", url, %{segments: []})
 
     url = 'http:path1/path2'
+
     %Res{
       input: ^url,
       rest: '',
@@ -517,9 +529,10 @@ defmodule ABNF_Test do
       string_text: ^url,
       string_tokens: ['http', ':', 'path1/path2', '', ''],
       values: _
-    } = ABNF.apply grammar, "uri", url, %{segments: []}
+    } = ABNF.apply(grammar, "uri", url, %{segments: []})
 
     url = 'http://[v1.fe80::a+en1]/path'
+
     %Res{
       input: ^url,
       rest: '',
@@ -533,11 +546,12 @@ defmodule ABNF_Test do
       string_text: ^url,
       string_tokens: ['http', ':', '//[v1.fe80::a+en1]/path', '', ''],
       values: _
-    } = ABNF.apply grammar, "uri", url, %{segments: []}
+    } = ABNF.apply(grammar, "uri", url, %{segments: []})
   end
 
   test "can reduce rule" do
-    grammar = load "reduce"
+    grammar = load("reduce")
+
     %Res{
       input: '123asd',
       rest: '',
@@ -545,13 +559,14 @@ defmodule ABNF_Test do
       string_text: '123asd',
       string_tokens: ['123', 'asd'],
       values: [%{int: 123, string: "asd"}]
-    } = ABNF.apply grammar, "composed", '123asd', %{field: false}
+    } = ABNF.apply(grammar, "composed", '123asd', %{field: false})
   end
 
   test "teluri" do
-    grammar = load "RFC3966"
+    grammar = load("RFC3966")
 
     tel = 'tel:+1-201-555-0123'
+
     %Res{
       input: 'tel:+1-201-555-0123',
       rest: '',
@@ -559,9 +574,10 @@ defmodule ABNF_Test do
       string_text: 'tel:+1-201-555-0123',
       string_tokens: ['tel:', '+1-201-555-0123'],
       values: _
-    } = ABNF.apply grammar, "telephone-uri", tel, %{}
+    } = ABNF.apply(grammar, "telephone-uri", tel, %{})
 
     tel = 'tel:863-1234;phone-context=+1-914-555'
+
     %Res{
       input: 'tel:863-1234;phone-context=+1-914-555',
       rest: '',
@@ -569,12 +585,13 @@ defmodule ABNF_Test do
       string_text: 'tel:863-1234;phone-context=+1-914-555',
       string_tokens: ['tel:', '863-1234;phone-context=+1-914-555'],
       values: _
-    } = ABNF.apply grammar, "telephone-uri", tel, %{}
+    } = ABNF.apply(grammar, "telephone-uri", tel, %{})
   end
 
   test "sdp" do
-    grammar = load "RFC4566"
-    data = to_char_list(File.read! "test/resources/sdp1.txt")
+    grammar = load("RFC4566")
+    data = to_charlist(File.read!("test/resources/sdp1.txt"))
+
     %Res{
       input: ^data,
       rest: '',
@@ -607,12 +624,13 @@ defmodule ABNF_Test do
         'm=audio 49170 RTP/AVP 0 8 97\r\na=rtpmap:0 PCMU/8000\r\na=rtpmap:8 PCMA/8000\r\na=rtpmap:97 iLBC/8000\r\nm=video 51372 RTP/AVP 31 32\r\na=rtpmap:31 H261/90000\r\na=rtpmap:32 MPV/90000\r\n'
       ],
       values: _
-      } = ABNF.apply grammar, "session-description", data, %{}
+    } = ABNF.apply(grammar, "session-description", data, %{})
   end
 
   test "sip" do
-    grammar = load "RFC3261"
-    data = to_char_list(File.read! "test/resources/sip1.txt")
+    grammar = load("RFC3261")
+    data = to_charlist(File.read!("test/resources/sip1.txt"))
+
     %Res{
       input: ^data,
       rest: '',
@@ -640,15 +658,17 @@ defmodule ABNF_Test do
       },
       string_text: ^data,
       string_tokens: [^data]
-    } = ABNF.apply grammar, "SIP-message", data, %{
-      headers: %{}
-    }
+    } =
+      ABNF.apply(grammar, "SIP-message", data, %{
+        headers: %{}
+      })
   end
 
   test "email" do
-    grammar = load "RFC5322-no-obs"
+    grammar = load("RFC5322-no-obs")
 
     email = 'user@domain.com'
+
     %Res{
       input: ^email,
       rest: '',
@@ -659,9 +679,10 @@ defmodule ABNF_Test do
       string_text: ^email,
       string_tokens: ['user@domain.com'],
       values: _
-    } = ABNF.apply grammar, "mailbox", email, %{}
+    } = ABNF.apply(grammar, "mailbox", email, %{})
 
     email = '<user@domain.com>'
+
     %Res{
       input: ^email,
       rest: '',
@@ -672,9 +693,10 @@ defmodule ABNF_Test do
       string_text: ^email,
       string_tokens: ['<user@domain.com>'],
       values: _
-    } = ABNF.apply grammar, "mailbox", email, %{}
+    } = ABNF.apply(grammar, "mailbox", email, %{})
 
     email = 'Peter Cantropus <user@domain.com>'
+
     %Res{
       input: ^email,
       rest: '',
@@ -686,9 +708,10 @@ defmodule ABNF_Test do
       string_text: ^email,
       string_tokens: ['Peter Cantropus <user@domain.com>'],
       values: _
-    } = ABNF.apply grammar, "mailbox", email, %{}
+    } = ABNF.apply(grammar, "mailbox", email, %{})
 
     input = '21 Nov 1997 10:01:22 -0600'
+
     %Res{
       input: ^input,
       rest: '',
@@ -704,9 +727,10 @@ defmodule ABNF_Test do
       string_text: ^input,
       string_tokens: [[], '21 Nov 1997 ', '10:01:22 -0600', []],
       values: _
-    } = ABNF.apply grammar, "date-time", input, %{}
+    } = ABNF.apply(grammar, "date-time", input, %{})
 
     input = 'Received: from node.example by x.y.test; 21 Nov 1997 10:01:22 -0600\r\n'
+
     %Res{
       input: ^input,
       rest: '',
@@ -721,48 +745,62 @@ defmodule ABNF_Test do
         year: '1997'
       },
       string_text: ^input,
-      string_tokens: ['Received:', ' from node.example by x.y.test', ';', ' 21 Nov 1997 10:01:22 -0600', '\r\n'],
+      string_tokens: [
+        'Received:',
+        ' from node.example by x.y.test',
+        ';',
+        ' 21 Nov 1997 10:01:22 -0600',
+        '\r\n'
+      ],
       values: _
-    } = ABNF.apply grammar, "Received", input, %{}
+    } = ABNF.apply(grammar, "Received", input, %{})
   end
 
   # Load grammars before tests are run
   def init() do
     me = self()
-    spawn fn ->
-      :ets = :ets.new :ets, [:named_table, :public, {:read_concurrency, true}]
+
+    spawn(fn ->
+      :ets = :ets.new(:ets, [:named_table, :public, {:read_concurrency, true}])
+
       for t <- [
-        "ipv4",
-        "ipv6",
-        "path",
-        "reduce",
-        "basic",
-        "RFC7405",
-        "RFC3261",
-        "RFC3966",
-        "RFC3986",
-        "RFC4566",
-        "module_code",
-        "RFC5322-no-obs"
-      ] do
+            "ipv4",
+            "ipv6",
+            "path",
+            "reduce",
+            "basic",
+            "RFC7405",
+            "RFC3261",
+            "RFC3966",
+            "RFC3986",
+            "RFC4566",
+            "module_code",
+            "RFC5322-no-obs"
+          ] do
         :ets.insert_new(
-          :ets, {t, ABNF.load_file("test/resources/#{t}.abnf")}
+          :ets,
+          {t, ABNF.load_file("test/resources/#{t}.abnf")}
         )
-        :timer.sleep 1
+
+        :timer.sleep(1)
       end
-      send me, :done
+
+      send(me, :done)
+
       receive do
         _ -> :ok
       end
-    end
+    end)
+
     receive do
       :done -> :ok
     end
+
     :ok
   end
 
   defp load(file) do
-    [{^file, grammar}] = :ets.lookup :ets, file
+    [{^file, grammar}] = :ets.lookup(:ets, file)
     grammar
   end
 end

--- a/test/resources/RFC5322-no-obs.abnf
+++ b/test/resources/RFC5322-no-obs.abnf
@@ -47,13 +47,13 @@ date            =   day month year !!!
   {:ok, Map.put(state, :year, :lists.flatten(y))}
 !!!
 day             =   ([FWS] 1*2DIGIT FWS)  !!!
-  {:ok, state, to_char_list String.strip(to_string(rule))}
+  {:ok, state, to_charlist String.strip(to_string(rule))}
 !!!
 month           =   "Jan" / "Feb" / "Mar" / "Apr" /
                     "May" / "Jun" / "Jul" / "Aug" /
                     "Sep" / "Oct" / "Nov" / "Dec"
 year            =   (FWS 4*DIGIT FWS) !!!
-  {:ok, state, to_char_list String.strip(to_string(rule))}
+  {:ok, state, to_charlist String.strip(to_string(rule))}
 !!!
 time            =   time-of-day zone !!!
   [_, tz] = values
@@ -70,7 +70,7 @@ second          =   2DIGIT !!!
   {:ok, Map.put(state, :second, rule)}
 !!!
 zone            =   (FWS ( "+" / "-" ) 4DIGIT) !!!
-  {:ok, state, to_char_list String.strip(to_string(rule))}
+  {:ok, state, to_charlist String.strip(to_string(rule))}
 !!!
 address         =   mailbox / group
 mailbox         =   name-addr / addr-spec


### PR DESCRIPTION
It looks like there are a lot of changes but that is the Elixir 1.8 formatter. The actual differences are:

- change char_list to charlist
- change to_char_list to to_charlist
- add `:unicode` to the :re.compile() call to handle unicode characters.
- iolist_size fails on a list like [8220] which you get if curly quotes are included in the text to parse so I added a fast_length method to interpreter.ex that handles 0, 1, 2, 3 length charlists and falls back to :erlang.length() for longer lists. (It works, but feels like a hack.)

Feel free to take or reject these changes. It was motivated by trying to write a tokenizer like the classic tokenizer in lucene. You can see what I was trying here: https://github.com/baldmountain/lucille I needed the changes to get my project to successfully parse the text version of Tom Sawyer downloaded from Project Gutenberg. ABNF is probably too slow for this since is interpreted. I may try something else. Just wanted to pass on my changes in case they are useful.
